### PR TITLE
Post-launch tweaks: monthly refresh, light default, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # npm dependencies (Astro, integrations, tooling)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      npm-dependencies:
+        patterns: ["*"]
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 24, cache: npm }
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,19 +1,89 @@
 name: Lighthouse
+# Manual: comment "/lighthouse" on a PR to run an audit and get the report as a comment.
 on:
-  pull_request:
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lighthouse-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   lighthouse:
+    # Only on PR comments that start with /lighthouse, from the repo owner/collaborators.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/lighthouse') &&
+      contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
+      - name: Acknowledge the command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
       - uses: actions/checkout@v4
+      - name: Check out the PR's head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
       - uses: actions/setup-node@v4
         with: { node-version: 24, cache: npm }
       - run: npm ci
       - run: npm run build
+
       - name: Run Lighthouse CI
+        id: lhci
         uses: treosh/lighthouse-ci-action@v12
         with:
           configPath: ./lighthouserc.json
           uploadArtifacts: true
+
+      - name: Post report as a PR comment
+        uses: actions/github-script@v7
+        env:
+          MANIFEST: ${{ steps.lhci.outputs.manifest }}
+          LINKS: ${{ steps.lhci.outputs.links }}
+        with:
+          script: |
+            const manifest = JSON.parse(process.env.MANIFEST || '[]');
+            const links = JSON.parse(process.env.LINKS || '{}');
+            const runs = manifest.filter((m) => m.isRepresentativeRun);
+            const pct = (v) => (v == null ? '–' : Math.round(v * 100));
+            const dot = (v) => (v >= 0.9 ? '🟢' : v >= 0.5 ? '🟠' : '🔴');
+            const cell = (v) => `${dot(v)} ${pct(v)}`;
+            const rows = runs.map((m) => {
+              const s = m.summary;
+              const path = new URL(m.url).pathname.replace('/index.html', '/') || '/';
+              const link = links[m.url];
+              const name = link ? `[\`${path}\`](${link})` : `\`${path}\``;
+              return `| ${name} | ${cell(s.performance)} | ${cell(s.accessibility)} | ${cell(s['best-practices'])} | ${cell(s.seo)} |`;
+            }).join('\n');
+            const body = [
+              '## 🔦 Lighthouse report',
+              '',
+              `Commit \`${context.sha.slice(0, 7)}\` · scores are 🟢 ≥90 · 🟠 50–89 · 🔴 <50`,
+              '',
+              '| Page | Performance | Accessibility | Best Practices | SEO |',
+              '|---|---|---|---|---|',
+              rows,
+              '',
+              '_Click a page for the full report (links expire in ~7 days). Re-run anytime by commenting `/lighthouse`._',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,19 @@
+name: Lighthouse
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 24, cache: npm }
+      - run: npm ci
+      - run: npm run build
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true

--- a/.github/workflows/refresh-publications.yml
+++ b/.github/workflows/refresh-publications.yml
@@ -1,7 +1,7 @@
 name: Refresh publications
 on:
   schedule:
-    - cron: '0 6 * * 1'   # every Monday 06:00 UTC
+    - cron: '0 6 1 * *'   # 06:00 UTC on the 1st of each month
   workflow_dispatch:
 
 permissions:
@@ -24,7 +24,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add src/data/publications.json
-            git commit -m "chore: weekly publications refresh"
+            git commit -m "chore: monthly publications refresh"
             git push
           else
             echo "no publication changes"

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,18 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "url": [
+        "http://localhost/index.html",
+        "http://localhost/cv/index.html",
+        "http://localhost/publications/index.html",
+        "http://localhost/projects/index.html",
+        "http://localhost/blog/index.html"
+      ],
+      "numberOfRuns": 1
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -9,7 +9,7 @@
         "http://localhost/projects/index.html",
         "http://localhost/blog/index.html"
       ],
-      "numberOfRuns": 1
+      "numberOfRuns": 3
     },
     "upload": {
       "target": "temporary-public-storage"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -9,7 +9,7 @@ const fullTitle = title ? `${title} · ${site.name}` : site.name;
 ---
 
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Small follow-ups after the Astro rebuild.

- **Publications refresh → monthly.** Cron changed from weekly (Mondays) to the 1st of each month (`0 6 1 * *`).
- **Default theme → light.** First-time visitors now land on the light theme; the toggle still persists a per-visitor choice.
- **Dependabot.** Added `.github/dependabot.yml` for monthly npm + GitHub Actions update PRs (grouped to keep noise down).

Note: the earlier `pages-build-deployment` (Jekyll) failure was the legacy branch-based Pages builder running during the source switch. Pages is now on GitHub Actions (`build_type: workflow`) and the Astro Deploy workflow succeeds, so that failure won't recur.