### PR TITLE
Fix mobile layout: hamburger nav + footer stacking

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,4 +32,9 @@ const links = [
   ul a:hover { color: var(--accent); }
   ul svg { width: 19px; height: 19px; }
   p { margin-left: auto; color: var(--text-muted); font-size: 0.8rem; }
+
+  @media (max-width: 600px) {
+    footer { flex-direction: column; align-items: flex-start; gap: 16px; }
+    p { margin-left: 0; }
+  }
 </style>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -8,22 +8,50 @@ const isActive = (href: string) =>
 
 <nav>
   <a class="brand mono" href="/">~/{site.brand}</a>
-  <ul>
-    {nav.map((item) => (
-      <li>
-        <a class={`link mono ${isActive(item.href) ? 'active' : ''}`} href={item.href}>
-          {isActive(item.href) ? '> ' : ''}{item.label}
-        </a>
-      </li>
-    ))}
-  </ul>
-  <ThemeToggle />
+  <button id="nav-toggle" class="nav-toggle mono" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">☰</button>
+  <div id="nav-menu" class="menu">
+    <ul>
+      {nav.map((item) => (
+        <li>
+          <a class={`link mono ${isActive(item.href) ? 'active' : ''}`} href={item.href}>
+            {isActive(item.href) ? '> ' : ''}{item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+    <ThemeToggle />
+  </div>
 </nav>
 
 <style>
   nav { display: flex; align-items: center; gap: 24px; padding: 18px 0; border-bottom: 1px solid var(--border); }
   .brand { color: var(--accent); font-weight: 700; }
-  ul { list-style: none; display: flex; gap: 22px; margin-left: auto; }
+  .nav-toggle {
+    display: none; margin-left: auto; cursor: pointer;
+    background: none; border: 1px solid var(--border); color: var(--text-muted);
+    border-radius: 6px; font-size: 1.1rem; line-height: 1; padding: 5px 10px;
+  }
+  .nav-toggle:hover { color: var(--accent); border-color: var(--accent); }
+  .menu { display: flex; align-items: center; gap: 22px; margin-left: auto; }
+  ul { list-style: none; display: flex; gap: 22px; }
   .link { color: var(--text-muted); font-size: 0.9rem; }
   .link.active { color: var(--accent); }
+
+  @media (max-width: 600px) {
+    nav { flex-wrap: wrap; gap: 0; }
+    .nav-toggle { display: inline-flex; }
+    .menu { display: none; width: 100%; flex-direction: column; align-items: flex-start; gap: 16px; margin: 16px 0 0; }
+    .menu.open { display: flex; }
+    ul { flex-direction: column; gap: 16px; }
+  }
 </style>
+
+<script>
+  const btn = document.getElementById('nav-toggle');
+  const menu = document.getElementById('nav-menu');
+  btn?.addEventListener('click', () => {
+    const open = menu?.classList.toggle('open');
+    btn.setAttribute('aria-expanded', String(!!open));
+    btn.textContent = open ? '✕' : '☰';
+  });
+</script>


### PR DESCRIPTION
Mobile/responsive fixes found while testing on a phone.

- **Nav → hamburger on small screens (≤600px).** The nav links were wrapping onto two lines. Now the nav collapses to `~/ajay` + a ☰ button; tapping reveals a vertical menu (home, cv, publications, projects, blog + theme toggle), ✕ to close. Desktop layout is unchanged.
- **Footer stacks on small screens.** The copyright used `margin-left:auto` and broke alignment when it wrapped. On ≤600px the footer now stacks vertically (icons row, then copyright, left-aligned).

Verified at a 390×844 phone viewport (collapsed nav, open menu, stacked footer) and at desktop width (unchanged).