### PR TITLE
Replace mobile hamburger menu with two-row header

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -8,7 +8,6 @@ const isActive = (href: string) =>
 
 <nav>
   <a class="brand mono" href="/">~/{site.brand}</a>
-  <button id="nav-toggle" class="nav-toggle mono" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">☰</button>
   <div id="nav-menu" class="menu">
     <ul>
       {nav.map((item) => (
@@ -19,39 +18,25 @@ const isActive = (href: string) =>
         </li>
       ))}
     </ul>
-    <ThemeToggle />
   </div>
+  <ThemeToggle />
 </nav>
 
 <style>
   nav { display: flex; align-items: center; gap: 24px; padding: 18px 0; border-bottom: 1px solid var(--border); }
   .brand { color: var(--accent); font-weight: 700; }
-  .nav-toggle {
-    display: none; margin-left: auto; cursor: pointer;
-    background: none; border: 1px solid var(--border); color: var(--text-muted);
-    border-radius: 6px; font-size: 1.1rem; line-height: 1; padding: 5px 10px;
-  }
-  .nav-toggle:hover { color: var(--accent); border-color: var(--accent); }
   .menu { display: flex; align-items: center; gap: 22px; margin-left: auto; }
   ul { list-style: none; display: flex; gap: 22px; }
   .link { color: var(--text-muted); font-size: 0.9rem; }
   .link.active { color: var(--accent); }
 
+  /* Mobile: deliberate two-row header — brand + theme toggle on top,
+     full-width nav links row below. */
   @media (max-width: 600px) {
     nav { flex-wrap: wrap; gap: 0; }
-    .nav-toggle { display: inline-flex; }
-    .menu { display: none; width: 100%; flex-direction: column; align-items: flex-start; gap: 16px; margin: 16px 0 0; }
-    .menu.open { display: flex; }
-    ul { flex-direction: column; gap: 16px; }
+    .brand { margin-right: auto; }
+    .menu { order: 1; width: 100%; margin: 14px 0 0; }
+    ul { flex: 1; justify-content: space-between; gap: 0; }
+    .link { font-size: 0.82rem; }
   }
 </style>
-
-<script>
-  const btn = document.getElementById('nav-toggle');
-  const menu = document.getElementById('nav-menu');
-  btn?.addEventListener('click', () => {
-    const open = menu?.classList.toggle('open');
-    btn.setAttribute('aria-expanded', String(!!open));
-    btn.textContent = open ? '✕' : '☰';
-  });
-</script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,10 +1,10 @@
-<button id="theme-toggle" class="mono" aria-label="Toggle color theme">[theme]</button>
+<button id="theme-toggle" class="mono" aria-label="Toggle color theme"></button>
 
 <style>
   #theme-toggle {
-    font-family: var(--font-mono); font-size: 0.85rem; cursor: pointer;
+    font-family: var(--font-mono); font-size: 0.95rem; line-height: 1; cursor: pointer;
     background: none; border: 1px solid var(--border); color: var(--text-muted);
-    border-radius: 6px; padding: 4px 8px;
+    border-radius: 6px; padding: 5px 8px;
   }
   #theme-toggle:hover { color: var(--accent); border-color: var(--accent); }
 </style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 export const site = {
   name: 'Ajay Melekamburath',
   brand: 'ajay',
-  role: 'Computational Chemistry | C++ | High-performance Computing',
+  role: 'Computational Chemistry | C++ | High-Performance Computing',
   bio: 'Graduate student in the Valeev Group at Virginia Tech, working on many-body electronic structure methods and the scientific software behind them.',
   orcidId: '0000-0002-0079-5443',
   email: '', // optional: set to render a contact link

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -63,3 +63,8 @@ h1, h2, h3 { color: var(--text-strong); line-height: 1.2; }
   font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent);
   border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px; display: inline-block;
 }
+
+/* Theme toggle icon — reflects the current theme, driven by data-theme
+   (resolved before paint) so it never flashes. \FE0E forces text glyph. */
+#theme-toggle::before { content: '\2600\FE0E'; } /* ☀ light */
+html[data-theme='dark'] #theme-toggle::before { content: '\263E'; } /* ☾ dark */


### PR DESCRIPTION
## Summary

On mobile the nav previously collapsed behind a hamburger menu. Removing it naively caused the brand + 5 links + theme toggle to wrap awkwardly onto two lines with the toggle overflowing the edge. This redesigns the mobile header into a deliberate two-row layout instead.

## Changes

- **Remove the hamburger** button and its open/close script.
- **Two-row mobile header** (≤600px): `~/ajay` brand + theme toggle on the top row, full-width nav links row below. Desktop is unchanged (single row).
- **Theme toggle is now an icon** (`☀` light / `☾` dark) instead of `[theme]` text. The glyph is driven by `data-theme` in CSS so it resolves before paint with no flash.

## Verification

- Verified at 390px (mobile) and 1000px (desktop) via Playwright — no wrapping, links spread full-width, toggle reflects current theme.
- `npm run build` (7 pages) and `npm test` (6 tests) both pass.